### PR TITLE
eval code for sparse impl

### DIFF
--- a/chem_tensorflow_dense.py
+++ b/chem_tensorflow_dense.py
@@ -130,6 +130,8 @@ class DenseGGNNChemModel(ChemModel):
 
     # ----- Data preprocessing and chunking into minibatches:
     def process_raw_graphs(self, raw_data: Sequence[Any], is_training_data: bool, bucket_sizes=None) -> Any:
+        #import pdb
+        #pdb.set_trace()
         if bucket_sizes is None:
             bucket_sizes = np.array(list(range(4, 28, 2)) + [29])
         bucketed = defaultdict(list)
@@ -255,6 +257,11 @@ class DenseGGNNChemModel(ChemModel):
         n_example_molecules = 10
         with open('molecules_valid.json', 'r') as valid_file:
             example_molecules = json.load(valid_file)[:n_example_molecules]
+
+        #SAHIL
+        for mol in example_molecules:
+            print(mol['targets'])
+
         example_molecules, _, _ = self.process_raw_graphs(example_molecules, 
             is_training_data=False, bucket_sizes=np.array([29]))
         batch_data = self.make_batch(example_molecules[0])

--- a/chem_tensorflow_dense.py
+++ b/chem_tensorflow_dense.py
@@ -130,8 +130,6 @@ class DenseGGNNChemModel(ChemModel):
 
     # ----- Data preprocessing and chunking into minibatches:
     def process_raw_graphs(self, raw_data: Sequence[Any], is_training_data: bool, bucket_sizes=None) -> Any:
-        #import pdb
-        #pdb.set_trace()
         if bucket_sizes is None:
             bucket_sizes = np.array(list(range(4, 28, 2)) + [29])
         bucketed = defaultdict(list)
@@ -258,7 +256,6 @@ class DenseGGNNChemModel(ChemModel):
         with open('molecules_valid.json', 'r') as valid_file:
             example_molecules = json.load(valid_file)[:n_example_molecules]
 
-        #SAHIL
         for mol in example_molecules:
             print(mol['targets'])
 


### PR DESCRIPTION
Added evaluation code for sparse implementation, along the lines of the eval code for the dense representation case.

```python36 chem_tensorflow_sparse.py --restore <model_id>_model_best.pickle --evaluate``` gives output similar to:
```
	y_actual
		[[-0.8703278393436317]]
		[[-0.6274553605532948]]
		[[1.672936001814292]]
		[[-0.4367530669782174]]
		[[0.40862621249361225]]
		[[-1.0625337848735348]]
		[[-0.21440870617984975]]
		[[-0.6763567371711069]]
		[[0.07278881719187316]]
		[[1.465301279704437]]
	y_predicted	
		[-0.7689475  -0.6265423   1.3982722  -0.5135421   0.30170625 -0.80062336
		 -0.53425217 -0.6803084   0.17987642  1.4061637 ]
```
Signed-off-by: Sahil Suneja <sahilsuneja@gmail.com>